### PR TITLE
Add permissions_boundary variable for iam-role

### DIFF
--- a/iam-role.tf
+++ b/iam-role.tf
@@ -7,6 +7,7 @@ locals {
           attached_policy_arns = role_value.attached_policy_arns
           trust_anchor_name    = role_value.trust_anchor_name
           conditions           = role_value.conditions
+          permissions_boundary = role_value.permissions_boundary
         }
       ]
     ])
@@ -29,7 +30,8 @@ locals {
 resource "aws_iam_role" "iam_roles" {
   count = length(local.roles)
 
-  name = local.roles[count.index].name
+  name                 = local.roles[count.index].name
+  permissions_boundary = local.roles[count.index].permissions_boundary
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "profiles" {
       attached_policy_arns = list(string)
       trust_anchor_name    = string
       conditions           = optional(map(string))
-      permissions_boundary = string
+      permissions_boundary = optional(string)
     }))
 
     additional_tags             = optional(map(string), {})

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,7 @@ variable "profiles" {
       attached_policy_arns = list(string)
       trust_anchor_name    = string
       conditions           = optional(map(string))
+      permissions_boundary = string
     }))
 
     additional_tags             = optional(map(string), {})


### PR DESCRIPTION
Add permissions_boundary variable for iam-role. In our environment permissions_boundary is mandatory and without it we can't create the iam-role.